### PR TITLE
Add "collide" force

### DIFF
--- a/src/bubble_chart.js
+++ b/src/bubble_chart.js
@@ -19,9 +19,9 @@ function bubbleChart() {
   var center = { x: width / 2, y: height / 2 };
 
   var yearCenters = {
-    2008: { x: width / 3, y: height / 2 },
-    2009: { x: width / 2, y: height / 2 },
-    2010: { x: 2 * width / 3, y: height / 2 }
+    2008: { x: 160,         y: height / 2 },
+    2009: { x: width / 2,   y: height / 2 },
+    2010: { x: width - 160, y: height / 2 }
   };
 
   // X locations of the year titles.
@@ -57,6 +57,10 @@ function bubbleChart() {
     return -Math.pow(d.radius, 2.0) * forceStrength;
   }
 
+  var bubbleCollideForce = d3.forceCollide()
+    .radius(function(d) { return d.radius + 0.5; })
+    .iterations(3)
+  
   // Here we create a force layout and
   // @v4 We create a force simulation now and
   //  add forces to it.
@@ -64,7 +68,8 @@ function bubbleChart() {
     .velocityDecay(0.2)
     .force('x', d3.forceX().strength(forceStrength).x(center.x))
     .force('y', d3.forceY().strength(forceStrength).y(center.y))
-    .force('charge', d3.forceManyBody().strength(charge))
+    //.force('charge', d3.forceManyBody().strength(charge))
+    .force("collide", bubbleCollideForce)
     .on('tick', ticked);
 
   // @v4 Force starts up automatically,
@@ -99,7 +104,7 @@ function bubbleChart() {
     // @v4: new flattened scale names.
     var radiusScale = d3.scalePow()
       .exponent(0.5)
-      .range([2, 85])
+      .range([2, 65])
       .domain([0, maxAmount]);
 
     // Use map() to convert raw data into node data.


### PR DESCRIPTION
I figured out the difference between our implementations: you use a negative "charge" force to keep the bubbles apart, whereas I use a "collide" force.

Just comment out line 72 and uncomment line 71 to restore your behaviour:

```
    //.force('charge', d3.forceManyBody().strength(charge))
    .force("collide", bubbleCollideForce)
```

I had to shrink the bubbles slightly and increase their separation; otherwise, the collide force makes them take up too much space to separate.

I'm not really saying you should accept this pull request, but it illustrates the changes needed to get your force layout to look like mine (no collisions).

I think I actually like your [New York Times 2012 Obama budget](http://www.nytimes.com/interactive/2012/02/13/us/politics/2013-budget-proposal-graphic.html?_r=0) - style force layout better anyway, so [I've changed my fork](https://github.com/MichaelCurrie/bubble_chart/commit/8fd24fc7a16933aed344ba3942bc6279524e3434) to allow the option to be specified in `bubble_parameters.js`.